### PR TITLE
Pixel size value saved now.

### DIFF
--- a/relight-cli/main.cpp
+++ b/relight-cli/main.cpp
@@ -33,6 +33,7 @@ void help() {
     cout << "\t-y <int>  : number of Y planes in YCC\n\n";
 	cout << "\t-3 <radius[:offset]>: 3d light positions processing, ratio diameter_dome/image_width\n               and optionally vertical offset of the center of the sphere to the surface.\n";
 
+	cout << "\t-P <pixel size in MM>: this number is saved in .json output\n";
     //	cout << "\t-m <int>  : number of materials (default 8)\n";
 	cout << "\t-n        : extract normals\n";
 	cout << "\t-m        : extract mean image\n";
@@ -132,7 +133,14 @@ int main(int argc, char *argv[]) {
                 cerr << "Invalid resolution (must be 0 or >= 2 && <= 10)!\n" << endl;
                 return 1;
             }
-        }
+		}
+			break;
+		case 'P':
+			builder.pixelSize = atof(optarg);
+			if(builder.pixelSize <= 0) {
+				cerr << "Invalidi parameter pixelSize (-p): " << optarg << endl;
+				return 1;
+			}
             break;
         case 'b': {
             string b = optarg;

--- a/relight-cli/rtibuilder.h
+++ b/relight-cli/rtibuilder.h
@@ -18,6 +18,7 @@ typedef std::vector<std::vector<std::pair<int, float>>> Resamplemap;
 class RtiBuilder: public Rti {
 public:
 	ImageSet imageset;
+	float pixelSize = 0;
 	uint32_t samplingram = 500;
 	uint32_t nsamples = 1<<16; //TODO change to rate
 	float rangescale = 1.5;

--- a/relight/dome.cpp
+++ b/relight/dome.cpp
@@ -68,7 +68,12 @@ void Dome::fromJson(const QJsonObject &obj) {
 	imageWidth     = obj["imageWidth"].toDouble();
 	domeDiameter   = obj["domeDiameter"].toDouble();
 	verticalOffset = obj["verticalOffset"].toDouble();
-	lightConfiguration = LightConfiguration(lightConfigs.indexOf(obj["lightConfiguration"].toString()));
+	if(obj.contains("lightConfiguration")) {
+		lightConfiguration = DIRECTIONAL;
+		int index = lightConfigs.indexOf(obj["lightConfiguration"].toString());
+		if(index >= 0)
+			lightConfiguration = LightConfiguration(index);
+	}
 	::fromJson(obj["directions"].toArray(), directions);
 	::fromJson(obj["positions"].toArray(), positions);
 	::fromJson(obj["ledAdjust"].toArray(), ledAdjust);

--- a/relight/mainwindow.cpp
+++ b/relight/mainwindow.cpp
@@ -860,6 +860,9 @@ void MainWindow::exportRTI(bool normals) {
 
 
 	//should init with saved preferences.
+	project.computePixelSize();
+	rtiexport->pixelSize = project.pixelSize;
+
 	rtiexport->setTabIndex(normals? 1 : 0);
 	rtiexport->setImages(project.getImages());
 

--- a/relight/measure.h
+++ b/relight/measure.h
@@ -4,6 +4,7 @@
 
 
 #include <QPointF>
+#include <QLineF>
 
 class QJsonObject;
 
@@ -21,6 +22,16 @@ public:
 	void setFirstPoint(QPointF p);
 	void setSecondPoint(QPointF p);
 	void setLength(double d);
+	bool isValid() {
+		if(first.isNull() || second.isNull())
+			return false;
+		if(QLineF(first, second ).length() ==0)
+			return false;
+		return length > 0;
+	}
+	float pixelSize() {
+		return length/QLineF(first, second ).length();
+	}
 };
 
 #endif // MEASURE_H

--- a/relight/project.cpp
+++ b/relight/project.cpp
@@ -390,6 +390,17 @@ Measure *Project::newMeasure() {
 	measures.push_back(m);
 	return m;
 }
+void Project::computePixelSize() {
+	pixelSize = 0;
+	float count = 0;
+	for(Measure *m: measures)
+		if(m->isValid()) {
+			pixelSize += m->pixelSize();
+			count++;
+		}
+	pixelSize /= count;
+}
+
 Sphere *Project::newSphere() {
 	auto s = new Sphere(images.size());
 	spheres.push_back(s);

--- a/relight/project.h
+++ b/relight/project.h
@@ -31,6 +31,7 @@ public:
 	std::vector<Align *> aligns;
 	std::vector<White *> whites;
 	QRect crop;
+	float pixelSize = 0; //if computed from measures
 
 	Project() {}
 	~Project();
@@ -40,6 +41,7 @@ public:
 	void save(QString filename);
 	void saveLP(QString filename, std::vector<Vector3f> &directions);
 	void computeDirections();
+	void computePixelSize();
 
 	Measure *newMeasure();
 	Sphere *newSphere();

--- a/relight/rtiexport.cpp
+++ b/relight/rtiexport.cpp
@@ -298,6 +298,7 @@ void RtiExport::createRTI() {
 	task->addParameter("path", Parameter::FOLDER, path);
 	task->addParameter("output", Parameter::FOLDER, output);
 	task->addParameter("images", Parameter::STRINGLIST, images);
+	task->addParameter("pixelSize", Parameter::DOUBLE, pixelSize);
 
 	QList<QVariant> slights;
 	for(auto light: lights)

--- a/relight/rtiexport.h
+++ b/relight/rtiexport.h
@@ -22,6 +22,7 @@ class RtiExport : public QDialog
 public:
 	QStringList images;
 	std::vector<Vector3f> lights;
+	float pixelSize = 0;
 	QRect crop;
 	QString path;
 

--- a/relight/rtitask.cpp
+++ b/relight/rtitask.cpp
@@ -74,6 +74,7 @@ void RtiTask::run() {
 
 void  RtiTask::relight(bool commonMinMax, bool saveLegacy) {
 	builder = new RtiBuilder;
+	builder->pixelSize =(*this)["pixelSize"].value.toDouble();
 	builder->commonMinMax = commonMinMax;
 
 	builder->nworkers = QSettings().value("nworkers", 8).toInt();

--- a/src/imageset.cpp
+++ b/src/imageset.cpp
@@ -86,13 +86,13 @@ bool ImageSet::initFromFolder(const char *_path, bool ignore_filenames, int skip
 	return initImages(_path);
 }
 
-bool ImageSet::initFromProject(const char *filename) {
-	QFile file(filename);
+bool ImageSet::initFromProject(QJsonObject &obj, const QString &filename) {
+	/*QFile file(filename);
 	if(!file.open(QFile::ReadOnly))
 		throw QString("Failed opening: ") + QString(filename);
 
 	QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
-	QJsonObject obj = doc.object();
+	QJsonObject obj = doc.object(); */
 
 	QFileInfo info(filename);
 	QDir folder = info.dir();

--- a/src/imageset.h
+++ b/src/imageset.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <string>
 
+class QJsonObject;
 class JpegDecoder;
 class QImage;
 
@@ -38,7 +39,7 @@ public:
 
 
 	bool initFromFolder(const char *path, bool ignore_filenames = true, int skip_image = -1);
-	bool initFromProject(const char *filename);
+	bool initFromProject(QJsonObject &obj, const QString &filename);
 	void initLights();
 	bool initImages(const char *path); //require lights and images to be available, path points to the dir of the images.
 	


### PR DESCRIPTION
The set scale tool now saves the pixel size in the project and it is propagated in the .json relight format.

relight-cli now supports the -P <size> option where you can specify the scale which is saved in the .json relight format.