### PR TITLE
Pixel size information (DPI) now embedded in image metadata and fix to command-line parsing

### DIFF
--- a/relight-cli/main.cpp
+++ b/relight-cli/main.cpp
@@ -34,7 +34,7 @@ void help() {
     cout << "\t-y <int>  : number of Y planes in YCC\n\n";
 	cout << "\t-3 <radius[:offset]>: 3d light positions processing, ratio diameter_dome/image_width\n               and optionally vertical offset of the center of the sphere to the surface.\n";
 
-	cout << "\t-P <pixel size in MM>: this number is saved in .json output\n";
+	cout << "\t-P <pixel size in MM>: this number is saved in .json output and within image metadata\n";
     //	cout << "\t-m <int>  : number of materials (default 8)\n";
 	cout << "\t-n        : extract normals\n";
 	cout << "\t-m        : extract mean image\n";
@@ -112,7 +112,7 @@ int main(int argc, char *argv[]) {
 
 	opterr = 0;
     char c;
-	while ((c  = getopt (argc, argv, "hmMn3:r:d:q:p:s:c:reE:b:y:S:R:CD:B:L:k:v")) != -1)
+	while ((c  = getopt (argc, argv, "hmMn3:r:d:q:p:s:c:reE:b:y:S:R:CD:B:L:k:P:v")) != -1)
         switch (c)
         {
         case 'h':
@@ -132,19 +132,19 @@ int main(int argc, char *argv[]) {
             //	break;
         case 'r': {
             int res = atoi(optarg);
-            builder.resolution = res = atoi(optarg);
+            builder.resolution = res;
             if(res < 0 || res == 1 || res == 2 || res > 20) {
                 cerr << "Invalid resolution (must be 0 or >= 2 && <= 20)!\n" << endl;
                 return 1;
             }
-		}
-			break;
-		case 'P':
-			builder.pixelSize = atof(optarg);
-			if(builder.pixelSize <= 0) {
-				cerr << "Invalidi parameter pixelSize (-p): " << optarg << endl;
-				return 1;
-			}
+	    break;
+	}
+	case 'P':
+	    builder.pixelSize = atof(optarg);
+	    if(builder.pixelSize <= 0) {
+	        cerr << "Invalid parameter pixelSize (-P): " << optarg << endl;
+		return 1;
+	    }
             break;
         case 'b': {
             string b = optarg;

--- a/relight-cli/rtibuilder.cpp
+++ b/relight-cli/rtibuilder.cpp
@@ -1321,8 +1321,8 @@ size_t RtiBuilder::save(const string &output, int quality) {
 		encoders[i]->setColorSpace(JCS_RGB, 3);
 		encoders[i]->setJpegColorSpace(JCS_YCbCr);
 
-		// Set DPI if known. Need to convert as RtiBuilder stores DPI in mm/pixel whereas JPEG requires pixels/cm
-		if(pixelSize > 0) encoders[i]->setDPI(10.0/pixelSize);
+		// Set spatial resolution if known. Convert to pixels/m as RtiBuilder stores this in mm/pixel
+		if(pixelSize > 0) encoders[i]->setDotsPerMeter(1000.0/pixelSize);
 
 		if(!chromasubsampling)
 			encoders[i]->setChromaSubsampling(false);
@@ -1350,15 +1350,15 @@ size_t RtiBuilder::save(const string &output, int quality) {
 	QImage means  (width, height, QImage::Format_RGB32);
 	QImage medians(width, height, QImage::Format_RGB32);
 
-	// Set DPI if known. Need to convert as RtiBuilder stores DPI in mm/pixel whereas QImage requires pixels/m
+	// Set spatial resolution if known. Convert to pixels/m as RtiBuilder stores this in mm/pixel
 	if (pixelSize > 0) {
-	        int pixels_per_m = round(100.0/pixelSize);
-		normals.setDotsPerMeterX(pixels_per_m);
-		normals.setDotsPerMeterY(pixels_per_m);
-		means.setDotsPerMeterX(pixels_per_m);
-		means.setDotsPerMeterY(pixels_per_m);
-		medians.setDotsPerMeterX(pixels_per_m);
-		medians.setDotsPerMeterY(pixels_per_m);
+	        int dotsPerMeter = round(1000.0/pixelSize);
+		normals.setDotsPerMeterX(dotsPerMeter);
+		normals.setDotsPerMeterY(dotsPerMeter);
+		means.setDotsPerMeterX(dotsPerMeter);
+		means.setDotsPerMeterY(dotsPerMeter);
+		medians.setDotsPerMeterX(dotsPerMeter);
+		medians.setDotsPerMeterY(dotsPerMeter);
 	}
 
 	//colorspace check

--- a/relight-cli/rtibuilder.cpp
+++ b/relight-cli/rtibuilder.cpp
@@ -1320,7 +1320,10 @@ size_t RtiBuilder::save(const string &output, int quality) {
 		encoders[i]->setQuality(quality);
 		encoders[i]->setColorSpace(JCS_RGB, 3);
 		encoders[i]->setJpegColorSpace(JCS_YCbCr);
-		
+
+		// Set DPI if known. Need to convert as RtiBuilder stores DPI in mm/pixel whereas JPEG requires pixels/cm
+		if(pixelSize > 0) encoders[i]->setDPI(10.0/pixelSize);
+
 		if(!chromasubsampling)
 			encoders[i]->setChromaSubsampling(false);
 		
@@ -1347,6 +1350,16 @@ size_t RtiBuilder::save(const string &output, int quality) {
 	QImage means  (width, height, QImage::Format_RGB32);
 	QImage medians(width, height, QImage::Format_RGB32);
 
+	// Set DPI if known. Need to convert as RtiBuilder stores DPI in mm/pixel whereas QImage requires pixels/m
+	if (pixelSize > 0) {
+	        int pixels_per_m = round(100.0/pixelSize);
+		normals.setDotsPerMeterX(pixels_per_m);
+		normals.setDotsPerMeterY(pixels_per_m);
+		means.setDotsPerMeterX(pixels_per_m);
+		means.setDotsPerMeterY(pixels_per_m);
+		medians.setDotsPerMeterX(pixels_per_m);
+		medians.setDotsPerMeterY(pixels_per_m);
+	}
 
 	//colorspace check
 	if (savenormals) {

--- a/relight/normalstask.cpp
+++ b/relight/normalstask.cpp
@@ -94,11 +94,11 @@ void NormalsTask::run()
 
     // Save the final result
     QImage img(normalmap.data(), imageSet.width, imageSet.height, imageSet.width*3, QImage::Format_RGB888);
-    // Set DPI if known. Need to convert as pixelSize stored in mm/pixel whereas PNG requires pixels/m
+    // Set spatial resolution if known. Need to convert as pixelSize stored in mm/pixel whereas QImage requires pixels/m
     if( pixelSize > 0 ) {
-        int dpi = round(100.0/pixelSize);
-	img.setDotsPerMeterX(dpi);
-	img.setDotsPerMeterY(dpi);
+        int dotsPerMeter = round(1000.0/pixelSize);
+        img.setDotsPerMeterX(dotsPerMeter);
+        img.setDotsPerMeterY(dotsPerMeter);
     }
     img.save(output);
     std::function<bool(std::string s, int d)> callback = [this](std::string s, int n)->bool { return this->progressed(s, n); };

--- a/relight/normalstask.cpp
+++ b/relight/normalstask.cpp
@@ -94,8 +94,13 @@ void NormalsTask::run()
 
     // Save the final result
     QImage img(normalmap.data(), imageSet.width, imageSet.height, imageSet.width*3, QImage::Format_RGB888);
+    // Set DPI if known. Need to convert as pixelSize stored in mm/pixel whereas PNG requires pixels/m
+    if( pixelSize > 0 ) {
+        int dpi = round(100.0/pixelSize);
+	img.setDotsPerMeterX(dpi);
+	img.setDotsPerMeterY(dpi);
+    }
     img.save(output);
-
     std::function<bool(std::string s, int d)> callback = [this](std::string s, int n)->bool { return this->progressed(s, n); };
 
     if(exportSurface) {

--- a/relight/normalstask.h
+++ b/relight/normalstask.h
@@ -22,6 +22,7 @@ public:
     bool exportSurface = false;
     bool exportK = 2.0;
     QRect m_Crop;
+    float pixelSize = 0;
 
     NormalsTask(QString& inputPath, QString& outputPath, QRect crop, NormalSolver _solver) :
         solver(_solver), m_Crop(crop) {

--- a/relight/rtiexport.cpp
+++ b/relight/rtiexport.cpp
@@ -255,6 +255,7 @@ void RtiExport::createNormals() {
 
     ProcessQueue &queue = ProcessQueue::instance();
     NormalsTask *task = new NormalsTask(path, output, crop, solver);
+    if( pixelSize > 0 ) task->pixelSize = pixelSize;
     task->exportSurface = ui->export_surface->isChecked();
     task->exportK = ui->discontinuity->value();
 	QList<QVariant> slights;

--- a/src/jpeg_encoder.cpp
+++ b/src/jpeg_encoder.cpp
@@ -46,8 +46,8 @@ void JpegEncoder::setChromaSubsampling(bool subsample) {
 	this->subsample = subsample;
 }
 
-void JpegEncoder::setDPI(float dpi) {
-        this->dpi = round( dpi );
+void JpegEncoder::setDotsPerMeter(float dotsPerMeter) {
+        this->dotsPerMeter = round( dotsPerMeter / 100.0 );  // JPEG requires a resolution in pixels/cm
 }
 
 
@@ -90,9 +90,9 @@ bool JpegEncoder::encode(uint8_t* img, int width, int height) {
 	info.optimize_coding = (boolean)optimize;
 
 	// Set our output resolution if provided in pixels/cm
-	if(dpi>0) {
-	        info.X_density = dpi;
-		info.Y_density = dpi;
+	if(dotsPerMeter>0) {
+	        info.X_density = dotsPerMeter;
+		info.Y_density = dotsPerMeter;
 		info.density_unit = 2;   // 2 = pixels per cm
 	}
 
@@ -137,9 +137,9 @@ bool JpegEncoder::init(int width, int height) {
 	info.optimize_coding = (boolean)optimize;
 
 	// Set our output resolution if provided in pixels/cm
-	if(dpi>0) {
-	        info.X_density = dpi;
-		info.Y_density = dpi;
+	if(dotsPerMeter>0) {
+	        info.X_density = dotsPerMeter;
+		info.Y_density = dotsPerMeter;
 		info.density_unit = 2;   // 2 = pixels per cm
 	}
 

--- a/src/jpeg_encoder.cpp
+++ b/src/jpeg_encoder.cpp
@@ -47,7 +47,7 @@ void JpegEncoder::setChromaSubsampling(bool subsample) {
 }
 
 void JpegEncoder::setDotsPerMeter(float dotsPerMeter) {
-        this->dotsPerMeter = round( dotsPerMeter / 100.0 );  // JPEG requires a resolution in pixels/cm
+        this->dotsPerCM = round( dotsPerMeter / 100.0 );  // JPEG requires a resolution in pixels/cm
 }
 
 
@@ -90,9 +90,9 @@ bool JpegEncoder::encode(uint8_t* img, int width, int height) {
 	info.optimize_coding = (boolean)optimize;
 
 	// Set our output resolution if provided in pixels/cm
-	if(dotsPerMeter>0) {
-	        info.X_density = dotsPerMeter;
-		info.Y_density = dotsPerMeter;
+	if(dotsPerCM>0) {
+	        info.X_density = dotsPerCM;
+		info.Y_density = dotsPerCM;
 		info.density_unit = 2;   // 2 = pixels per cm
 	}
 
@@ -137,9 +137,9 @@ bool JpegEncoder::init(int width, int height) {
 	info.optimize_coding = (boolean)optimize;
 
 	// Set our output resolution if provided in pixels/cm
-	if(dotsPerMeter>0) {
-	        info.X_density = dotsPerMeter;
-		info.Y_density = dotsPerMeter;
+	if(dotsPerCM>0) {
+	        info.X_density = dotsPerCM;
+		info.Y_density = dotsPerCM;
 		info.density_unit = 2;   // 2 = pixels per cm
 	}
 

--- a/src/jpeg_encoder.cpp
+++ b/src/jpeg_encoder.cpp
@@ -1,5 +1,6 @@
 #include "jpeg_encoder.h"
 
+#include <cmath>
 #include <iostream>
 using namespace std;
 
@@ -45,6 +46,9 @@ void JpegEncoder::setChromaSubsampling(bool subsample) {
 	this->subsample = subsample;
 }
 
+void JpegEncoder::setDPI(float dpi) {
+        this->dpi = round( dpi );
+}
 
 
 bool JpegEncoder::encode(uint8_t* img, int width, int height, FILE* file) {
@@ -85,6 +89,13 @@ bool JpegEncoder::encode(uint8_t* img, int width, int height) {
 	jpeg_set_quality(&info, quality, (boolean)true);
 	info.optimize_coding = (boolean)optimize;
 
+	// Set our output resolution if provided in pixels/cm
+	if(dpi>0) {
+	        info.X_density = dpi;
+		info.Y_density = dpi;
+		info.density_unit = 2;   // 2 = pixels per cm
+	}
+
 	if(jpegColorSpace == JCS_YCbCr && subsample == false) {
 		for(int i = 0; i < numComponents; i++) {
 			info.comp_info[i].h_samp_factor = 1;
@@ -124,6 +135,13 @@ bool JpegEncoder::init(int width, int height) {
 	jpeg_set_colorspace(&info, jpegColorSpace);
 	jpeg_set_quality(&info, quality, (boolean)true);
 	info.optimize_coding = (boolean)optimize;
+
+	// Set our output resolution if provided in pixels/cm
+	if(dpi>0) {
+	        info.X_density = dpi;
+		info.Y_density = dpi;
+		info.density_unit = 2;   // 2 = pixels per cm
+	}
 
 	if(jpegColorSpace == JCS_YCbCr && subsample == false)
 		for(int i = 0; i < numComponents; i++) {

--- a/src/jpeg_encoder.h
+++ b/src/jpeg_encoder.h
@@ -24,6 +24,7 @@ public:
 	int getQuality() const;
 	void setOptimize(bool optimize);
 	void setChromaSubsampling(bool subsample);
+        void setDPI(float dpi);
 
 	bool encode(uint8_t *img, int width, int height, FILE* file);
 	bool encode(uint8_t *img, int width, int height, const char* path);
@@ -50,6 +51,7 @@ private:
 	bool subsample = false;
 
 	int quality = 95;
+        int dpi = 0;
 };
 
 #endif // JPEGENCODER_H_

--- a/src/jpeg_encoder.h
+++ b/src/jpeg_encoder.h
@@ -24,7 +24,7 @@ public:
 	int getQuality() const;
 	void setOptimize(bool optimize);
 	void setChromaSubsampling(bool subsample);
-        void setDPI(float dpi);
+        void setDotsPerMeter(float dotsPerMeter);
 
 	bool encode(uint8_t *img, int width, int height, FILE* file);
 	bool encode(uint8_t *img, int width, int height, const char* path);
@@ -51,7 +51,7 @@ private:
 	bool subsample = false;
 
 	int quality = 95;
-        int dpi = 0;
+        int dotsPerMeter = 0;
 };
 
 #endif // JPEGENCODER_H_

--- a/src/jpeg_encoder.h
+++ b/src/jpeg_encoder.h
@@ -51,7 +51,7 @@ private:
 	bool subsample = false;
 
 	int quality = 95;
-        int dotsPerMeter = 0;
+        int dotsPerCM = 0;
 };
 
 #endif // JPEGENCODER_H_


### PR DESCRIPTION
A set of commits related to handling pixel size information, including:

1. Fixing a bug in relight-cli when using the -P parameter (P was missing in the getopt list)
2. Adding the ability to embed pixel size information (DPI) within the metadata of both JPEG image planes as well as any normal, median or mean image export. This works when a relight RTI is saved either through the relight GUI or on the command-line