### PR TITLE
Refactoring: Fix Eigen3 configuration and deprecated API usage

### DIFF
--- a/relight-cli/CMakeLists.txt
+++ b/relight-cli/CMakeLists.txt
@@ -52,8 +52,14 @@ add_executable(relight-cli ${HEADERS} ${SOURCES})
 target_include_directories(
 	relight-cli PUBLIC 
 		${CMAKE_CURRENT_SOURCE_DIR}
-		${JPEG_INCLUDE_DIR}
-		${EIGEN3_INCLUDE_DIR})
+		${JPEG_INCLUDE_DIR})
+
+if(Eigen3_FOUND)
+	target_link_libraries(relight-cli PUBLIC Eigen3::Eigen)
+else()
+	target_include_directories(relight-cli PUBLIC ${EIGEN3_INCLUDE_DIR})
+endif()
+
 
 target_link_libraries(
 	relight-cli PUBLIC

--- a/relight-cli/main.cpp
+++ b/relight-cli/main.cpp
@@ -384,7 +384,7 @@ int main(int argc, char *argv[]) {
 			return -1;
 		}
 		test(input, redrawdir.toStdString(), light);
-		return 1;
+		return 0;
 	}
 
 	std::function<bool(QString stage, int percent)> *callback = nullptr;

--- a/relight-merge/CMakeLists.txt
+++ b/relight-merge/CMakeLists.txt
@@ -45,8 +45,13 @@ add_executable(relight-merge ${HEADERS} ${SOURCES})
 target_include_directories(
 	relight-merge PUBLIC 
 		${CMAKE_CURRENT_SOURCE_DIR}
-		${JPEG_INCLUDE_DIR}
-		${EIGEN3_INCLUDE_DIR})
+		${JPEG_INCLUDE_DIR})
+
+if(Eigen3_FOUND)
+	target_link_libraries(relight-merge PUBLIC Eigen3::Eigen)
+else()
+	target_include_directories(relight-merge PUBLIC ${EIGEN3_INCLUDE_DIR})
+endif()		
 
 target_link_libraries(
 	relight-merge PUBLIC

--- a/relight-normals/CMakeLists.txt
+++ b/relight-normals/CMakeLists.txt
@@ -88,9 +88,13 @@ add_executable(relight-normals ${SOURCES} ${HEADERS})
 target_include_directories(relight-normals PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}
 		${JPEG_INCLUDE_DIR}
-		${EIGEN3_INCLUDE_DIR}
 		../external
 )
+if(Eigen3_FOUND)
+	target_link_libraries(relight-normals PUBLIC Eigen3::Eigen)
+else()
+	target_include_directories(relight-normals PUBLIC ${EIGEN3_INCLUDE_DIR})
+endif()
 
 target_link_libraries(
 	relight-normals PUBLIC

--- a/relight/CMakeLists.txt
+++ b/relight/CMakeLists.txt
@@ -150,10 +150,14 @@ target_include_directories(
 		${CMAKE_CURRENT_SOURCE_DIR}
 		${JPEG_INCLUDE_DIR}
 		TIFF::TIFF
-		${EIGEN3_INCLUDE_DIR}
 		../external
 	)
 
+if(Eigen3_FOUND)
+	target_link_libraries(relight PUBLIC Eigen3::Eigen)
+else()
+	target_include_directories(relight PUBLIC ${EIGEN3_INCLUDE_DIR})
+endif()
 
 target_link_libraries(
 	relight PUBLIC

--- a/relightlab/CMakeLists.txt
+++ b/relightlab/CMakeLists.txt
@@ -195,11 +195,16 @@ target_include_directories(
 		${CMAKE_CURRENT_SOURCE_DIR}
 		${JPEG_INCLUDE_DIR}
 		TIFF::TIFF
-		${EIGEN3_INCLUDE_DIR}
 		${OpenCV_INCLUDE_DIRS}
 		../external
 	)
 	
+if(Eigen3_FOUND)
+	target_link_libraries(relightlab PUBLIC Eigen3::Eigen)
+else()
+	target_include_directories(relightlab PUBLIC ${EIGEN3_INCLUDE_DIR})
+endif()
+
 target_link_libraries(
 	relightlab PUBLIC
 		${JPEG_LIBRARIES}

--- a/src/cli/rtibuilder.cpp
+++ b/src/cli/rtibuilder.cpp
@@ -437,7 +437,8 @@ MaterialBuilder RtiBuilder::pickBasePTM(std::vector<Vector3f> &lights) {
 				}
 			}
 		}
-		mat.svd.compute(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+		// DEPRECATED mat.svd.compute(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+		mat.svd = Eigen::JacobiSVD<Eigen::MatrixXf>(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
 		mat.useEigen = true;
 	} else {
 		if(colorspace == LRGB) {

--- a/src/sphere.cpp
+++ b/src/sphere.cpp
@@ -394,7 +394,9 @@ Vector3f intersection(std::vector<Line> &lines) {
 		A(i, 2) = lines[i].direction[2];
 		B(i) = lines[i].origin.dot(lines[i].direction);
 	}
-	Eigen::VectorXd X = A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(B);
+	// DEPRECATED Eigen::VectorXd X = A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(B);
+	Eigen::VectorXd X = Eigen::JacobiSVD<Eigen::MatrixXd>(A, Eigen::ComputeThinU | Eigen::ComputeThinV).solve(B);
+  // Faster for big matrices Eigen::VectorXd X = Eigen::BDCSVD<Eigen::MatrixXd>(A, Eigen::ComputeThinU | Eigen::ComputeThinV).solve(B);
 	return Vector3f(X[0], X[1], X[2]);
 }
 


### PR DESCRIPTION
Updated CMakeLists.txt with modern cmake config for Eigen.

Replaced deprecated jacobiSvd() method calls with modern Eigen3 API:
sphere.cpp (line 397)
rtibuilder.cpp (line 440)